### PR TITLE
Moving method name extraction into condition

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -18,8 +18,7 @@ export default (function () {
               if (logLevels.indexOf(logLevel) >= logLevels.indexOf(options.logLevel) &&
                   options.isEnabled) {
                   logger[logLevel] = (...args) => {
-                      let methodName = getMethodName()
-                      const methodNamePrefix = options.showMethodName ? methodName + ` ${options.separator} ` : ''
+                      const methodNamePrefix = options.showMethodName ? getMethodName() + ` ${options.separator} ` : ''
                       const logLevelPrefix = options.showLogLevel ? logLevel + ` ${options.separator} ` : ''
                       const formattedArguments = options.stringifyArguments ? args.map(a => JSON.stringify(a)) : args
                       print(logLevel, logLevelPrefix, methodNamePrefix, formattedArguments, options.showConsoleColors)

--- a/src/logger.js
+++ b/src/logger.js
@@ -33,18 +33,18 @@ export default (function () {
     }
 
     function print (logLevel = false, logLevelPrefix = false, methodNamePrefix = false, formattedArguments = false, showConsoleColors = false) {
-        let arguments = [];
+        let logArguments = [];
         if(logLevelPrefix !== '') {
-            arguments.push(logLevelPrefix);
+            logArguments.push(logLevelPrefix);
         }
         if(methodNamePrefix !== '') {
-            arguments.push(methodNamePrefix);
+            logArguments.push(methodNamePrefix);
         }
-        arguments = [...arguments, ...formattedArguments];
+        logArguments = [...arguments, ...formattedArguments];
         if (showConsoleColors && (logLevel === 'warn' || logLevel === 'error' || logLevel === 'fatal')) {
-            console[logLevel === 'fatal' ? 'error' : logLevel](...arguments)
+            console[logLevel === 'fatal' ? 'error' : logLevel](...logArguments)
         } else {
-            console.log(...arguments)
+            console.log(...logArguments)
         }
     }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -33,10 +33,18 @@ export default (function () {
     }
 
     function print (logLevel = false, logLevelPrefix = false, methodNamePrefix = false, formattedArguments = false, showConsoleColors = false) {
+        let arguments = [];
+        if(logLevelPrefix !== '') {
+            arguments.push(logLevelPrefix);
+        }
+        if(methodNamePrefix !== '') {
+            arguments.push(methodNamePrefix);
+        }
+        arguments = [...arguments, ...formattedArguments];
         if (showConsoleColors && (logLevel === 'warn' || logLevel === 'error' || logLevel === 'fatal')) {
-            console[logLevel === 'fatal' ? 'error' : logLevel](logLevelPrefix, methodNamePrefix, ...formattedArguments)
+            console[logLevel === 'fatal' ? 'error' : logLevel](...arguments)
         } else {
-            console.log(logLevelPrefix, methodNamePrefix, ...formattedArguments)
+            console.log(...arguments)
         }
     }
 


### PR DESCRIPTION
By moving the method call directly into the condition the method name extraction will only be executed if configured by the user. Otherwise it will be done with every single log call even if showMethodName is set to false by the user.